### PR TITLE
Support new :reduce task type

### DIFF
--- a/src/onyx_viz/core.cljs
+++ b/src/onyx_viz/core.cljs
@@ -11,7 +11,9 @@
   (case (:onyx/type task)
     :input "type-input"
     :function "type-function"
-    :output "type-output"))
+    :reduce "type-function"
+    :output "type-output"
+    ""))
 
 ;; TODO: switch this to sablono and render to html
 (defn style-tooltip [task-name->entry name]


### PR DESCRIPTION
This adds support for the new `:reduce` task type and uses an empty class name as a default for any future types added.